### PR TITLE
Image, Button, and CSS Updates 

### DIFF
--- a/Moffat_Bay_EW/build/classes/.gitignore
+++ b/Moffat_Bay_EW/build/classes/.gitignore
@@ -1,1 +1,0 @@
-/mbTools/

--- a/Moffat_Bay_EW/src/main/webapp/CSS/aboutus1.css
+++ b/Moffat_Bay_EW/src/main/webapp/CSS/aboutus1.css
@@ -32,12 +32,13 @@ h1 {
   display: flex;
   justify-content: center;
   background-color: #847968;
-  padding: 10px 0;
-  margin-top: 10px;
+  padding: 5px;
+  margin: 20px 25px 20px;
 }
 
- .top-tabs a {
-  padding: 10px 20px;
+.top-tabs a {
+  padding: 5px;
+  margin: 20px 25px 20px;
   color: white;
   text-align: center;
   text-decoration: none;

--- a/Moffat_Bay_EW/src/main/webapp/CSS/moffat2.css
+++ b/Moffat_Bay_EW/src/main/webapp/CSS/moffat2.css
@@ -3,15 +3,15 @@ body {
   margin: 0;
   padding: 0;
   background: url('MoffatBay/images/PacificNorthwest.jpg') no-repeat center top, #65e9f0;
-  background-size: 100% 75%, 100% 50%;
-  background-attachment: fixed;
+  background-size: 50px;
+  background-attachment: fixed; 
+
 }
 
 .banner{
-	margin-top: 0;
-	width: 100%;
-	/* aspect-ratio: 4/1; */	
-	justify-content:center;
+    position: relative;
+    padding: 20px;
+    text-align: center;
 }
 
 /*-------------------------*/
@@ -38,13 +38,13 @@ body {
   display: flex;
   justify-content: center;
   background-color: #847968;
-  padding: 10px 0;
-  margin-top: 20px;
-  z-index: -1;
+  padding: 5px;
+  margin: 20px 25px 20px;
 }
 
 .top-tabs a {
-  padding: 10px 20px;
+  padding: 5px;
+  margin: 20px 25px 20px;
   color: white;
   text-align: center;
   text-decoration: none;
@@ -356,6 +356,7 @@ textarea {
 
 .registration-form input[type="submit"] {
   padding: 10px;
+  margin: 25px;
   background-color: #f29f5a;
   color: white;
   border: none;

--- a/Moffat_Bay_EW/src/main/webapp/MoffatHome.html
+++ b/Moffat_Bay_EW/src/main/webapp/MoffatHome.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div class = "banner">
-  <img src="images-refined/Pacific_Northwest_beach_cove.jpg" alt="Moffat Bay View of Sea">
+  <img src="images-refined/Pacific_Northwest_beach_cove.jpg" alt="Moffat Bay View of Sea" width="1200" height="600" text-align="center">
  </div>   
 <!--  /////////////////////////  -->  
 <!--  Don't replace on home page due to banner.  -->

--- a/Moffat_Bay_EW/src/main/webapp/aboutus_jg.html
+++ b/Moffat_Bay_EW/src/main/webapp/aboutus_jg.html
@@ -10,7 +10,7 @@
 <!--  /////////////////////////  -->
 <!-- Not using universal header due to banner image -->
     <header>
-        <img src="images/PacificNorthwest.jpg" alt="Moffat Bay Resort Logo" class="banner">
+        <img src="images/PacificNorthwest.jpg" alt="Moffat Bay Resort Logo" width="1200" height="600">
         <h1>Moffat Bay Resort</h1>
     </header>
  <div class="top-tabs">

--- a/Moffat_Bay_EW/src/main/webapp/registration.jsp
+++ b/Moffat_Bay_EW/src/main/webapp/registration.jsp
@@ -32,9 +32,10 @@
     <input type="text" id="phone" name="phone" placeholder="xxx-xxx-xxxx" required>
     <span class = "errorMessages">${phoneErr}</span>
     
-    <label for="age">Age:</label>
+    <%-- <label for="age">Age:</label>
     <input type="number" id="age" name="age" placeholder="99" required>
     <span class = "errorMessages">${ageErr}</span>
+    --%>
     
     <label for="password">Password:</label>
     <input type="password" id="password" name="regPass" placeholder="Create a password" required>
@@ -42,6 +43,10 @@
 	
     <label for="confirm-password">Confirm Password:</label>
     <input type="password" id="confirm-password" name="repeatPass" placeholder="Confirm your password" required>
+    
+    <label for="age-confirmation">I confirm that I am over the age of 18:</label>
+    <input type="checkbox" id="age-confirmation" name="ageConfirmation" value="over18" required>
+    <span class="errorMessages">${ageErr}</span>
 
 	<input type="hidden" name="myrequest" value="register"/>
     <input type="submit" value="Register">


### PR DESCRIPTION
updated pictures in home and about us page, added checkbox requirement for age in registration page, adjusted other css around images so everything looked similar

Here is a full description for each:
- changed padding and margins on moffat2.css in the top-tabs section to widen the buttons 
- Changed age requirement entry to an age checkbox requiring to check a box and put a margin in to space the button out on the registration-form input of 25px(amanda feedback)
- matched css for top-tabs in aboutus1.css from moffat2.css 
- added image width and heigh to img src on MoffatHome.html and aboutus_jg.html
- adjusted .banner on both moffat2.css and aboutus1.css to make sure header pictures were center in the page no matter what